### PR TITLE
セッション取得の修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { Top } from "@/components/top";
 import { createClient } from "@/utils/supabase/server";
 
 // メインページ
@@ -10,15 +11,19 @@ const Home = async () => {
   /**
    *  supabase.auth.getSession()を使用して、現在のユーザーのログイン情報の取得
    */
-  const { data: session } = await supabase.auth.getSession();
-  console.log(session);
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
   return (
     /**
      *  三項演算子でログインの有無により、ページの出し分け
      */
-    <div className="text-center text-xl">
-      {session ? <div>ログイン済だよ</div> : <div>未ログインだよ</div>}
-    </div>
+    /**
+     * TODO:
+     * このコンポーネントはサーバーコンポーネントなので、デフォルトでは動的にUIを変更することはできません
+     * そのため、クライアントコンポーネントの使用を検討すると良いですね
+     */
+    <Top session={session} />
   );
 };
 

--- a/src/app/setting/logout/page.tsx
+++ b/src/app/setting/logout/page.tsx
@@ -9,6 +9,7 @@ const LogoutPage = async () => {
   /**
    * TODO: 以下の理由によりコメントアウトしておきます！
    * createServerComponentClientは使わない方が良い
+   * リダイレクト先のパスは正しくは"/login"ですかね？
    * ログイン状態でない場合のリダイレクト処理はログアウトページだけでなく、全てのページで共通の処理なので、共通化した方が良い
    */
   // const supabase = createServerComponentClient<Database>({

--- a/src/app/setting/logout/page.tsx
+++ b/src/app/setting/logout/page.tsx
@@ -6,19 +6,24 @@ import Logout from "@/components/logout";
 
 // ログアウトページ
 const LogoutPage = async () => {
-  const supabase = createServerComponentClient<Database>({
-    cookies,
-  });
+  /**
+   * TODO: 以下の理由によりコメントアウトしておきます！
+   * createServerComponentClientは使わない方が良い
+   * ログイン状態でない場合のリダイレクト処理はログアウトページだけでなく、全てのページで共通の処理なので、共通化した方が良い
+   */
+  // const supabase = createServerComponentClient<Database>({
+  //   cookies,
+  // });
 
-  // セッションの取得
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
+  // // セッションの取得
+  // const {
+  //   data: { session },
+  // } = await supabase.auth.getSession();
 
-  // 未認証の場合、リダイレクト
-  if (!session) {
-    redirect("/auth/login");
-  }
+  // // 未認証の場合、リダイレクト
+  // if (!session) {
+  //   redirect("/auth/login");
+  // }
 
   return <Logout />;
 };

--- a/src/components/login.tsx
+++ b/src/components/login.tsx
@@ -81,7 +81,8 @@ const Login = () => {
         return;
       }
 
-      router.push('/'); // ここもリダイレクト処理があるか確認
+      // TODO: src/app/auth/callback/route.tsでログイン後のリダイレクト処理があるので不要ですね
+      // router.push('/'); // ここもリダイレクト処理があるか確認
     } catch (error) {
       setMessage('エラーが発生しました。' + error);
     } finally {

--- a/src/components/logout.tsx
+++ b/src/components/logout.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { FormEvent, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { useRouter } from "next/navigation";
 import Loading from "@/app/loading";
-import type { Database } from "@/lib/database.types";
+import { createClient } from "@/utils/supabase/client";
 
 // ログアウト
 const Logout = () => {
   const router = useRouter();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createClient();
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
 

--- a/src/components/supabase-listener.tsx
+++ b/src/components/supabase-listener.tsx
@@ -1,44 +1,42 @@
 "use server";
 // クライアントに渡す前に、認証状態の確認をするから
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
-import type { Database } from "@/lib/database.types";
 import Navigation from "./navigation";
+import { createClient } from "@/utils/supabase/server";
 
 // 認証状態の監視
 const SupabaseListener = async () => {
-  const supabase = createServerComponentClient<Database>({ cookies });
-
   // セッションの取得
+  const supabaseClient = createClient();
   const {
     data: { session },
-  } = await supabase.auth.getSession();
+  } = await supabaseClient.auth.getSession();
 
+  // TODO: プロフィール用のテーブルは今はないのでコメントアウトしておきますね
   // プロフィールの取得
-  let profile = null;
-  if (session) {
-    const { data: currentProfile } = await supabase
-      .from("profiles")
-      .select("*")
-      .eq("id", session.user.id)
-      .single();
+  // let profile = null;
+  // if (session) {
+  //   const { data: currentProfile } = await supabase
+  //     .from("profiles")
+  //     .select("*")
+  //     .eq("id", session.user.id)
+  //     .single();
 
-    profile = currentProfile;
+  //   profile = currentProfile;
 
-    // メールアドレスを変更した場合、プロフィールを更新
-    if (currentProfile && currentProfile.email !== session.user.email) {
-      // メールアドレスを更新
-      const { data: updatedProfile } = await supabase
-        .from("profiles")
-        .update({ email: session.user.email })
-        .match({ id: session.user.id })
-        .select("*")
-        .single();
+  //   // メールアドレスを変更した場合、プロフィールを更新
+  //   if (currentProfile && currentProfile.email !== session.user.email) {
+  //     // メールアドレスを更新
+  //     const { data: updatedProfile } = await supabase
+  //       .from("profiles")
+  //       .update({ email: session.user.email })
+  //       .match({ id: session.user.id })
+  //       .select("*")
+  //       .single();
 
-      profile = updatedProfile;
-    }
-  }
+  //     profile = updatedProfile;
+  //   }
+  // }
 
   // その結果をナビゲーションに渡す
   return <Navigation session={session} profile={null} />;

--- a/src/components/top.tsx
+++ b/src/components/top.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { Session } from '@supabase/supabase-js';
+
+export const Top = ({ session }: { session: Session | null }) => {
+  return <div className="text-center text-xl">{session ? <div>ログイン済だよ</div> : <div>未ログインだよ</div>}</div>;
+};


### PR DESCRIPTION
## 修正前
1. 最初使っていた@supabase/auth-helpers-nextjsのメソッドと後から修正・追加した@/utils/supabase配下に作成したメソッドが混在していたため、正常に動作していなかった
2. サーバーコンポーネントはデフォルトで初回の読み込み以降生成されたリソースをキャッシュするので、トップ画面（/app/page.tsx）のUIは更新されない状態であった
    1. 参考：https://nextjs.org/docs/app/building-your-application/rendering/server-components#static-rendering-default 
3. src/app/setting/logout/page.tsxでログアウト処理後に/auth/loginに遷移する挙動になっていた

## 修正後
1. @/utils/supabase配下に作成したメソッドを使うように一部修正しました！
2. 表示するUIをクライアントコンポーネントにしました！他にも以下の方法があります
    1. https://stackoverflow.com/questions/75124513/update-server-component-after-data-has-been-changed-by-client-component-in-next
    2. https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic
3. セッションを取得してnullであればログイン画面に遷移する処理は一旦コメントアウトしました！

## その他
`TODO`の接頭辞をつけてコメントしたので、確認してみてくださいmm
@supabase/auth-helpers-nextjsのメソッドはまだ残っているので、修正を検討してみてください！
3のセッションを取得してnullであればログイン画面に遷移する処理は共通処理なので、どこか１箇所で定義して実現したいですね。